### PR TITLE
Fixed multipart content type format for boundary to comply with RFC 1341 specs

### DIFF
--- a/balena-cam/app/server.py
+++ b/balena-cam/app/server.py
@@ -137,7 +137,7 @@ async def mjpeg_handler(request):
     boundary = "frame"
     response = web.StreamResponse(status=200, reason='OK', headers={
         'Content-Type': 'multipart/x-mixed-replace; '
-                        'boundary=--%s' % boundary,
+                        'boundary=%s' % boundary,
     })
     await response.prepare(request)
     while True:


### PR DESCRIPTION
Adresses issue at:
https://github.com/balena-io-projects/balena-cam/issues/51

From RFC 1341 spec on multipart content type format:

_The encapsulation boundary is defined as a line consisting entirely of two hyphen characters ("-", decimal code 45) followed by the boundary parameter value from the Content-Type header field._

...

_Thus, a typical multipart Content-Type header field might look like this:_

> Content-Type: multipart/mixed;
> boundary=gc0p4Jq0M2Yt08jU534c0p

_This indicates that the entity consists of several parts, each itself with a structure that is syntactically identical to an RFC 822 message, except that the header area might be completely empty, and that the parts are each preceded by the line_

> --gc0p4Jq0M2Yt08jU534c0p