### PR TITLE
Simplify Chrome-specific instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,16 @@ If you have access to a TURN server and you want your balenaCam devices to use i
 - A direct WebRTC connection fails in some cases.
 - This current version uses mjpeg streaming when the webRTC connection fails.
 - Chrome browsers will hide the local IP address from WebRTC, making the page appear but no camera view. To resolve this try the following
-  - Enter this URL in your browser: chrome://flags
-  - Ensure the media flag is enabled (this will give you access to other features)
-  - Now set "Anonymize local IPs exposed by WebRTC" to Disabled
-  - Refresh your app page
+  - Navigate to chrome://flags/#enable-webrtc-hide-local-ips-with-mdns and set it to Disabled
+  - You will need to relaunch Chrome after altering the setting
 - Firefox may also hide local IP address from WebRTC, confirm following in 'config:about'
   - media.peerconnection.enabled: true
   - media.peerconnection.ice.obfuscate_host_addresses: false
 
 ## Supported Browsers
 
-- **Chrome**
-- **Firefox**
+- **Chrome** (but see note above)
+- **Firefox** (but see note above)
 - **Safari**
 - **Edge** (only mjpeg stream)
 


### PR DESCRIPTION
Provide a direct link to the flag which needs to be altered.

Remove sentence about Chrome 'media' settings. This appears to no longer exist.