### PR TITLE
docs: add query string params to deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Running this project is as simple as deploying it to a balenaCloud application.
 
 One-click deploy to balenaCloud:
 
-[![](https://balena.io/deploy.png)](https://dashboard.balena-cloud.com/deploy)
+[![deploy button](https://balena.io/deploy.png)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/balenalabs/balena-cam)
 
 **or**
 


### PR DESCRIPTION
Add query string params to deploy link to fix issue with stripping of referrer details on certain platforms.

Change-type: patch
Signed-off-by: Aaron Shaw <shawaj@gmail.com>